### PR TITLE
patch undef data passed in GET request

### DIFF
--- a/lib/WWW/Splunk/API.pm
+++ b/lib/WWW/Splunk/API.pm
@@ -153,6 +153,11 @@ sub request {
 	# Construct the request
 	my $request;
 	if (ref $method and ref $method eq 'CODE') {
+ 
+ 		# HTTP::Request::Common doesn't like being passed undef for $data..
+ 		my %empty = (empty=>'1');
+		$data = \%empty unless (defined($data));
+
 		# Most likely a HTTP::Request::Common
 		$request = $method->($url, $data);
 	} else {


### PR DESCRIPTION
this is to correct an evolving bug in the API client that presents itself in patched 5.14 and 5.16 perl versions.
when checking the splunk jobs, (and no data is needed to be passed as params .. like search_done.. ) the HTTP::Request::Common::Get chokes on the undef:
Illegal field name '' at /opt/ActivePerl-5.16/site/lib/HTTP/Request/Common.pm line 115.

probably a more root cause fix, but this gets us back and working in our environments..
